### PR TITLE
Versionning auto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
 
       - run: npm run lint
 
-
   publish:
     <<: *defaults
     steps:
@@ -55,6 +54,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run: cp ~/repo/README.md ~/repo/lib/README.md
       - run: cp ~/repo/package.json ~/repo/lib/package.json
+      - run: cd ~/repo/lib && npm version --no-git-tag-version ${CIRCLE_TAG}
       - run: npm publish ~/repo/lib --access public
 
 workflows:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-promql",
-  "version": "1.5.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-promql",
-  "version": "1.5.1",
+  "version": "0.0.0",
   "description": "Bundle of promql language for the Monaco Editor.",
   "scripts": {
     "build": "mrmdir ./lib && tsc -p ./src/tsconfig.json",


### PR DESCRIPTION
Using CIRCLE_TAG environment variable and npm version to not have to manage ourselves the version field of the package.json

This PR has been done to fix the failed pipeline : https://circleci.com/gh/prometheus-community/monaco-promql/30#tests/containers/0