### PR TITLE
Fix `main` and `types` paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "watch": "tsc -p ./src --watch",
     "test": "mocha"
   },
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
These paths should refer to the files as they end up in the NPM package. For more information, please see #20.