### PR TITLE
fix: remove extra `[` from `hexdigits`

### DIFF
--- a/src/promql/promql.ts
+++ b/src/promql/promql.ts
@@ -209,7 +209,7 @@ export const language = {
 	digits: /\d+(_+\d+)*/,
 	octaldigits: /[0-7]+(_+[0-7]+)*/,
 	binarydigits: /[0-1]+(_+[0-1]+)*/,
-	hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+	hexdigits: /[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
 	integersuffix: /(ll|LL|u|U|l|L)?(ll|LL|u|U|l|L)?/,
 	floatsuffix: /[fFlL]?/,
 


### PR DESCRIPTION


**What is this feature?**

The regex for `hexdigits` contained an extra `[` character. I do think `hexdigits` is not used at all, but I guess it's better to have a correct regex.