### PR TITLE
chore: Introduce dependency to prometheus to get keywords

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+export * from './lib/index';
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+export * from './lib/index';
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "monaco-promql",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@prometheus-io/codemirror-promql": "0.311.3"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.61.1",
         "@typescript-eslint/parser": "^8.61.1",
@@ -83,6 +86,69 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
+      "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -173,6 +239,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -221,6 +288,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -460,6 +528,39 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -507,6 +608,37 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prometheus-io/codemirror-promql": {
+      "version": "0.311.3",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/codemirror-promql/-/codemirror-promql-0.311.3.tgz",
+      "integrity": "sha512-WgfC910pn/EHcwC9zRPwO8hGbT0G2eS5uvGi4GCAtKLY68SqfjIXaewvOMyR3avnIjoL7c45WpxkD5++df8omQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prometheus-io/lezer-promql": "0.311.3",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/view": "^6.4.0",
+        "@lezer/common": "^1.0.1"
+      }
+    },
+    "node_modules/@prometheus-io/lezer-promql": {
+      "version": "0.311.3",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/lezer-promql/-/lezer-promql-0.311.3.tgz",
+      "integrity": "sha512-2MmOiYa4DNAkav12w8g5hSCZgGDEKFoT2Y6kqmhdhlXvP8zyACv3mx+wOqmJdkX0zLP0KZyjrQIOZtAXIHlnsA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@lezer/highlight": "^1.1.2",
+        "@lezer/lr": "^1.2.3"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -611,6 +743,7 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -799,6 +932,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1010,6 +1144,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1185,6 +1325,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1762,16 +1903,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1835,6 +1966,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/marked": {
@@ -2490,6 +2630,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2567,6 +2713,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2665,6 +2812,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2705,6 +2853,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "monaco-editor",
     "prometheus"
   ],
+  "dependencies": {
+    "@prometheus-io/codemirror-promql": "0.305.0"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prometheus"
   ],
   "dependencies": {
-    "@prometheus-io/codemirror-promql": "0.305.0"
+    "@prometheus-io/codemirror-promql": "0.311.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.61.1",

--- a/src/promql/promql.ts
+++ b/src/promql/promql.ts
@@ -29,6 +29,12 @@ import CompletionList = languages.CompletionList;
 import CompletionItemProvider = languages.CompletionItemProvider;
 import CompletionItem = languages.CompletionItem;
 
+import {
+	aggregateOpModifierTerms,
+	aggregateOpTerms, atModifierTerms, binOpModifierTerms, binOpTerms,
+	functionIdentifierTerms
+} from "@prometheus-io/codemirror-promql/dist/cjs/complete/promql.terms";
+
 // noinspection JSUnusedGlobalSymbols
 export const languageConfiguration: IRichLanguageConfiguration = {
 	// the default separators except `@$`
@@ -60,137 +66,20 @@ export const languageConfiguration: IRichLanguageConfiguration = {
 	folding: {}
 };
 
-// PromQL Aggregation Operators
-// (https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators)
-const aggregations = [
-	'sum',
-	'min',
-	'max',
-	'avg',
-	'group',
-	'stddev',
-	'stdvar',
-	'count',
-	'count_values',
-	'bottomk',
-	'topk',
-	'quantile',
-	'limitk',
-	'limit_ratio',
-];
-
-// PromQL functions
-// (https://prometheus.io/docs/prometheus/latest/querying/functions/)
-const functions = [
-	'abs',
-	'absent',
-	'ceil',
-	'changes',
-	'clamp',
-	'clamp_max',
-	'clamp_min',
-	'day_of_month',
-	'day_of_week',
-	'day_of_year',
-	'days_in_month',
-	'delta',
-	'deriv',
-	'exp',
-	'floor',
-	'histogram_avg',
-	'histogram_count',
-	'histogram_sum',
-	'histogram_fraction',
-	'histogram_quantile',
-	'histogram_stddev',
-	'histogram_stdvar',
-	'double_exponential_smoothing',
-	'holt_winters', // keep it in case it's still v2
-	'hour',
-	'idelta',
-	'increase',
-	'info',
-	'irate',
-	'label_join',
-	'label_replace',
-	'ln',
-	'log2',
-	'log10',
-	'minute',
-	'month',
-	'predict_linear',
-	'rate',
-	'resets',
-	'round',
-	'scalar',
-	'sgn',
-	'sort',
-	'sort_desc',
-	'sort_by_label',
-	'sort_by_label_desc',
-	'sqrt',
-	'time',
-	'timestamp',
-	'vector',
-	'year',
-];
-
-// PromQL trigonometric functions
-// https://prometheus.io/docs/prometheus/latest/querying/functions/#trigonometric-functions
-const trigonometricFunctions = [
-	'acos',
-	'acosh',
-	'asin',
-	'asinh',
-	'atan',
-	'atanh',
-	'cos',
-	'cosh',
-	'sin',
-	'sinh',
-	'tan',
-	'tanh',
-	'deg',
-	'pi',
-	'rad',
-];
-
-// PromQL specific functions: Aggregations over time
-// (https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time)
-const aggregationsOverTime = [];
-for (const agg of aggregations) {
-	aggregationsOverTime.push(agg + '_over_time');
-}
-
-// PromQL vector matching + the by and without clauses
-// (https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching)
-const vectorMatching = [
-	'on',
-	'ignoring',
-	'group_right',
-	'group_left',
-	'by',
-	'without',
-];
+const vectorMatching = binOpModifierTerms.map(t => t.label).concat(aggregateOpModifierTerms.map(t => t.label)).concat(atModifierTerms.map(t => t.label));
 // Produce a regex matching elements : (elt1|elt2|...)
 const vectorMatchingRegex = `(${vectorMatching.reduce((prev, curr) => `${prev}|${curr}`)})`;
 
 // PromQL Operators
 // (https://prometheus.io/docs/prometheus/latest/querying/operators/)
-const operators = [
-	'+', '-', '*', '/', '%', '^',
-	'==', '!=', '>', '<', '>=', '<=',
-	'and', 'or', 'unless',
-];
-
-// PromQL offset modifier
-// (https://prometheus.io/docs/prometheus/latest/querying/basics/#offset-modifier)
-const offsetModifier = [
-	'offset',
-];
+const operators = binOpTerms.map(t => t.label)
 
 // Merging all the keywords in one list
-const keywords = aggregations.concat(functions).concat(trigonometricFunctions).concat(aggregationsOverTime).concat(vectorMatching).concat(offsetModifier);
+const keywords = aggregateOpTerms.map(t => t.label)
+	.concat(functionIdentifierTerms.map(t => t.label))
+	.concat(binOpModifierTerms.map(t => t.label))
+	.concat(atModifierTerms.map(t => t.label))
+	.concat(aggregateOpModifierTerms.map(t => t.label));
 
 // noinspection JSUnusedGlobalSymbols
 export const language = {


### PR DESCRIPTION
I would like to stop maintaining anything and let the version updates do it for me. So I am introducing a dependency to the prometheus codemirror engine. 

It would be good if we can have all the terms more explicitely exported from the lib so I wouldn't have to do a strange import. Except if I am not doing it correctly
```ts
import {
	aggregateOpModifierTerms,
	aggregateOpTerms, atModifierTerms, binOpModifierTerms, binOpTerms,
	functionIdentifierTerms
} from "@prometheus-io/codemirror-promql/dist/cjs/complete/promql.terms";
```

Here is the diff before/after for the managed keywords

### Only in old
~bottomk_over_time~ -> not existing
~count_values_over_time~  -> not existing
~group_over_time~  -> not existing
holt_winters -> a real one that has been removed in recent prometheus
~limit_ratio_over_time~  -> not existing
~limitk_over_time~ -> not existing
offset -> yes missing but also from codemirror !
~topk_over_time~  -> not existing

### Only in new
absent_over_time
end()
last_over_time
mad_over_time
present_over_time
start()
ts_of_last_over_time
ts_of_max_over_time
ts_of_min_over_time