### PR TITLE
chore: use type-only monaco type imports

### DIFF
--- a/src/promql/promql.ts
+++ b/src/promql/promql.ts
@@ -21,13 +21,13 @@
 // SOFTWARE.
 
 'use strict';
-import { languages } from "monaco-editor";
-import IRichLanguageConfiguration = languages.LanguageConfiguration;
-import ILanguage = languages.IMonarchLanguage;
-import ProviderResult = languages.ProviderResult;
-import CompletionList = languages.CompletionList;
-import CompletionItemProvider = languages.CompletionItemProvider;
-import CompletionItem = languages.CompletionItem;
+import { languages as monacoLanguages, type languages } from "monaco-editor";
+type IRichLanguageConfiguration = languages.LanguageConfiguration;
+type ILanguage = languages.IMonarchLanguage;
+type ProviderResult<T> = languages.ProviderResult<T>;
+type CompletionList = languages.CompletionList;
+type CompletionItemProvider = languages.CompletionItemProvider;
+type CompletionItem = languages.CompletionItem;
 
 import {
 	aggregateOpModifierTerms,
@@ -195,13 +195,12 @@ export const completionItemProvider: CompletionItemProvider = {
 		const suggestions = keywords.map(value => {
 			return {
 				label: value,
-				kind: languages.CompletionItemKind.Keyword,
+				kind: monacoLanguages.CompletionItemKind.Keyword,
 				insertText: value,
-				insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet
+				insertTextRules: monacoLanguages.CompletionItemInsertTextRule.InsertAsSnippet
 			} as CompletionItem
 		});
 
 		return {suggestions} as ProviderResult<CompletionList>;
 	}
 };
-


### PR DESCRIPTION
## What

Changes the Monaco import in `src/promql/promql.ts` to a single mixed import that keeps the runtime `languages` binding for completion item enum values and marks the type namespace usage as type-only.

## Why

This makes the type-only usage explicit without replacing Monaco enum references with local numeric constants. The package still imports `monaco-editor` at runtime because the completion provider depends on Monaco's runtime enum namespace.

## Testing

- `npm run build`
- `npm run lint` (passes with existing warnings about unused eslint-disable directives)

Note: `npm test` currently fails before exercising this change because `test/setup.js` expects a global AMD `define` function.
